### PR TITLE
Fix prompt usage update and breadcrumb typo

### DIFF
--- a/src/api/prompts.ts
+++ b/src/api/prompts.ts
@@ -472,10 +472,24 @@ export async function recordPromptUsage(
   }
 
   // 2. Increment the usage count and update last_used_at
+  // Retrieve current usage count
+  const { data: promptData, error: fetchError } = await supabase
+    .from('prompts')
+    .select('use_count')
+    .eq('id', promptId)
+    .single();
+
+  if (fetchError) {
+    console.error('Error fetching prompt usage count:', fetchError);
+    return;
+  }
+
+  const newCount = (promptData?.use_count || 0) + 1;
+
   const { error: countError } = await supabase
     .from('prompts')
-    .update({ 
-      use_count: supabase.rpc('increment_prompt_usage', { x: 1 }),
+    .update({
+      use_count: newCount,
       last_used_at: new Date().toISOString()
     })
     .eq('id', promptId);

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -102,7 +102,7 @@ const BreadcrumbEllipsis = ({
     <span className="sr-only">More</span>
   </span>
 )
-BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+BreadcrumbEllipsis.displayName = "BreadcrumbEllipsis"
 
 export {
   Breadcrumb,


### PR DESCRIPTION
## Summary
- fix usage count update in `recordPromptUsage`
- correct typo in Breadcrumb component display name

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fd0d2395c83338a14259287326a0e